### PR TITLE
FIX: Check for existing log_thread correctly

### DIFF
--- a/app/controllers/client_performance/report_controller.rb
+++ b/app/controllers/client_performance/report_controller.rb
@@ -77,7 +77,7 @@ class ClientPerformance::ReportController < ApplicationController
 
     @@log_queue ||= Queue.new
 
-    if !@@log_thread || !@@log_thread.alive?
+    if !defined?(@@log_thread) || !@@log_thread.alive?
       @@log_thread = Thread.new do
         loop do
           @@logger << @@log_queue.pop


### PR DESCRIPTION
This was causing an 'uninitialized class variable' error.

Followup to 3e29acdb