### PR TITLE
FEATURE: reduce rate limit for logging

### DIFF
--- a/app/controllers/client_performance/report_controller.rb
+++ b/app/controllers/client_performance/report_controller.rb
@@ -48,8 +48,10 @@ class ClientPerformance::ReportController < ApplicationController
       "additionalProperties" => false
   }
 
+  LOGS_PER_10_SECONDS = 2
+
   def report
-    RateLimiter.new(nil, "client_performance_report_#{current_user&.id || request.client_ip}", 1, 1.minute).performed!
+    RateLimiter.new(nil, "client_performance_report_#{current_user&.id || request.client_ip}", LOGS_PER_10_SECONDS, 10).performed!
 
     begin
       reported_data = JSON.parse(params.require("data"))


### PR DESCRIPTION
Previously we only allowed 1 log per minute. This amends it so we allow 20.

Number is somewhat high, but we do not want to miss log messages 1 a minute
is too conservative.
