### PR TITLE
FEATURE: Log other metrics relative to ttfb

### DIFF
--- a/app/controllers/client_performance/report_controller.rb
+++ b/app/controllers/client_performance/report_controller.rb
@@ -94,10 +94,18 @@ class ClientPerformance::ReportController < ApplicationController
     data["user_agent"] = { "original" => request.user_agent }
     data["source"] = { "address" => request.remote_ip }
 
-    data["discourse"]["client_perf"] = {}
+    data["discourse"]["client_perf"] = {
+      "after_ttfb" => {}
+    }
+
+    ttfb = reported_data["time_to_first_byte"]
+
     NUMERIC_FIELDS.each do |f|
       if raw = reported_data[f]
         data["discourse"]["client_perf"][f] = (raw.to_f / 1000).round(3)
+        if f != "time_to_first_byte"
+          data["discourse"]["client_perf"]["after_ttfb"][f] = ((raw - ttfb).to_f / 1000).round(3)
+        end
       end
     end
 


### PR DESCRIPTION
When measuring CDN/JS performance, it can be useful to subtract ttfb from the other web vital metrics. Technically this could be done when processing/analysing the data, but it's easy enough to do it here and provide two versions of the metrics.