### PR TITLE
Update for new core init/paint metrics

### DIFF
--- a/app/controllers/client_performance/report_controller.rb
+++ b/app/controllers/client_performance/report_controller.rb
@@ -7,7 +7,8 @@ class ClientPerformance::ReportController < ApplicationController
 
   NUMERIC_FIELDS = %w[
     time_to_first_byte
-    discourse_booted
+    discourse_init
+    discourse_paint
     dom_content_loaded
     first_contentful_paint
     largest_contentful_paint

--- a/public/javascripts/discourse-client-performance.js
+++ b/public/javascripts/discourse-client-performance.js
@@ -64,8 +64,10 @@ class DiscourseClientPerformance {
       this.navigationEntry = e;
     } else if (e.entryType === "paint" && e.name === "first-contentful-paint") {
       this.firstContentfulPaintEntry = e;
-    } else if (e.entryType === "mark" && e.name === "discourse-booted") {
-      this.discourseBootEntry = e;
+    } else if (e.entryType === "mark" && e.name === "discourse-init") {
+      this.discourseInitEntry = e;
+    } else if (e.entryType === "mark" && e.name === "discourse-paint") {
+      this.discoursePaintEntry = e;
     }
     this.reportIfReady();
   }
@@ -83,7 +85,8 @@ class DiscourseClientPerformance {
     if (
       this.navigationEntry &&
       this.firstContentfulPaintEntry &&
-      this.discourseBootEntry &&
+      this.discourseInitEntry &&
+      this.discoursePaintEntry &&
       (!SUPPORTS_LCP || this.largestContentfulPaint) &&
       (!SUPPORTS_INP || this.interactionNextPaint)
     ) {
@@ -100,7 +103,8 @@ class DiscourseClientPerformance {
     const data = {};
 
     data["time_to_first_byte"] = this.navigationEntry?.responseStart;
-    data["discourse_booted"] = this.discourseBootEntry?.startTime;
+    data["discourse_init"] = this.discourseInitEntry?.startTime;
+    data["discourse_paint"] = this.discoursePaintEntry?.startTime;
     data["dom_content_loaded"] =
       this.navigationEntry?.domContentLoadedEventStart;
     data["first_contentful_paint"] = this.firstContentfulPaintEntry?.startTime;


### PR DESCRIPTION
- discourse-init is a direct replacement for the old discourse-booted metric.
- discourse-paint is a new metric which tells us when the Discourse UI is actually rendered to the screen

Ref https://github.com/discourse/discourse/pull/26758