### PR TITLE
FIX: Allow reports for anon on login-required sites

### DIFF
--- a/app/controllers/client_performance/report_controller.rb
+++ b/app/controllers/client_performance/report_controller.rb
@@ -3,7 +3,10 @@
 class ClientPerformance::ReportController < ApplicationController
   requires_plugin ClientPerformance::PLUGIN_NAME
 
-  skip_before_action :verify_authenticity_token, :check_xhr, :preload_json
+  skip_before_action :verify_authenticity_token,
+                     :check_xhr,
+                     :preload_json,
+                     :redirect_to_login_if_required
   before_action :skip_persist_session
 
   NUMERIC_FIELDS = %w[


### PR DESCRIPTION
Importantly, this means that the fix in c6718f999af7ec728e7a60cd99a9039736ca5594 will apply all the time, even for anon users on login-required sites